### PR TITLE
Replace 'brogrammer' reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 
       <ul>
         <li>We want to be inclusive; we don't welcome homophobic, racist, transphobic, or sexist behavior, amongst others.</li>
-        <li>We think feminism is a good thing. This isn't a place for aggression or elitism — Computering isn't a competition.</li>
+        <li>We think feminism is a good thing. Agression and elitism are unwelcome here -- computering is not a competition.</li>
         <li>We're a very informal and ad-hoc group right now, so if you piss us off you won't be invited again.</li>
         <li>Although we're meeting in a pub, there is no expectation or pressure to drink alcohol. Don't question anyone's choice of drink.</li>
       </ul>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 
       <ul>
         <li>We want to be inclusive; we don't welcome homophobic, racist, transphobic, or sexist behavior, amongst others.</li>
-        <li>We think feminism is a good thing. This isn't a club for boys, nor a place to demonstrate manliness or machismo.</li>
+        <li>We think feminism is a good thing. This isn't a place for aggression or elitism — Computering isn't a competition.</li>
         <li>We're a very informal and ad-hoc group right now, so if you piss us off you won't be invited again.</li>
         <li>Although we're meeting in a pub, there is no expectation or pressure to drink alcohol. Don't question anyone's choice of drink.</li>
       </ul>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 
       <ul>
         <li>We want to be inclusive; we don't welcome homophobic, racist, transphobic, or sexist behavior, amongst others.</li>
-        <li>We think feminism is a good thing; we think <a href="http://theweek.com/article/index/227356/brogramming-the-disturbing-rise-of-frat-culture-in-silicon-valley">brogramming</a> is a bad thing.</li>
+        <li>We think feminism is a good thing.</li>
         <li>We're a very informal and ad-hoc group right now, so if you piss us off you won't be invited again.</li>
         <li>Although we're meeting in a pub, there is no expectation or pressure to drink alcohol. Don't question anyone's choice of drink.</li>
       </ul>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 
       <ul>
         <li>We want to be inclusive; we don't welcome homophobic, racist, transphobic, or sexist behavior, amongst others.</li>
-        <li>We think feminism is a good thing.</li>
+        <li>We think feminism is a good thing. This isn't a club for boys, nor a place to demonstrate manliness or machismo.</li>
         <li>We're a very informal and ad-hoc group right now, so if you piss us off you won't be invited again.</li>
         <li>Although we're meeting in a pub, there is no expectation or pressure to drink alcohol. Don't question anyone's choice of drink.</li>
       </ul>


### PR DESCRIPTION
https://github.com/computeranonymous/computer/pull/39 for Reasons

Currently this doesn't replace it with anything; I suspect a replacement clause is needed, but don't know what.

As for Reasons:

From @russss https://github.com/computeranonymous/computer/pull/39#issuecomment-25318944:

> It's clear from this thread that we're not particularly sure how to define "brogramming". I'm increasingly unsure that the people who we want to exclude would identify as "brogrammers" anyway.
> 
> I think the main thing we want to avoid from "brogrammers" is casual sexism. These rules already cover that.

From @tef https://github.com/computeranonymous/computer/pull/39#issuecomment-25321699:

> I'm /mostly/ happy with this commit. I understand why we don't want to use brogrammer/dudebro, but i think we're missing out in that "Boys will be boys" is not welcome, people are expected to be adults and treat each other with respect*
