### PR TITLE
Set the time for SF meetup

### DIFF
--- a/us_sanfrancisco.html
+++ b/us_sanfrancisco.html
@@ -16,8 +16,9 @@
 
       <h2>The Meetings</h2>
 
-      <p>First meeting:</p>
+      <h3>First meeting</h3>
       
+      <p>Time: <strong>Saturday, Sep 5, 2013 at 6pm PST</strong></p>
       <p>Location: <a href="http://thesycamoresf.com/">The Sycamore</a>, 2140 Mission St (near 17th/Mission)</p>
       <ul>
         <li>Great food</li>
@@ -27,8 +28,6 @@
         <li>Across from Noisebridge</li>
         <li>Mission</li>
       </ul>
-
-      <p>Time: Please add yourself to the <a href="http://doodle.com/ne3dny5x5teauzcv">doodle!</a></p>
 
       <p>We've just gotten started! Join us on IRC if you want in. :)</p>
 


### PR DESCRIPTION
Baaasically, what it says on the tin: 
- Move the time up, 
- Set the "first meeting" thing to be an h3
- Set the meeting time to be next Saturday at 6pm.
