### PR TITLE
Use JavaScript to invert colours where possible

### DIFF
--- a/accessibility.js
+++ b/accessibility.js
@@ -1,0 +1,16 @@
+/*jslint indent: 2, browser: true */
+
+(function () {
+  'use strict';
+
+  if (document.addEventListener && document.documentElement.classList) {
+    document.addEventListener('click', function (event) {
+      var classes = event.target.classList;
+
+      if (classes.contains('color-change')) {
+        document.getElementById('accessibility').classList[classes.contains('wob') ? 'add' : 'remove']('inverted');
+        event.preventDefault();
+      }
+    });
+  }
+}());

--- a/ca_nl_stjohns.html
+++ b/ca_nl_stjohns.html
@@ -72,5 +72,6 @@
         rights to this work.
       </p>
     </section> 
+    <script src="accessibility.js"></script>
   </body>
 </html>

--- a/ca_qc_montreal.html
+++ b/ca_qc_montreal.html
@@ -39,5 +39,6 @@
         rights to this work.
       </p>
     </section> 
+    <script src="accessibility.js"></script>
   </body>
 </html>

--- a/de_berlin.html
+++ b/de_berlin.html
@@ -141,5 +141,6 @@
         rights to this work.
       </p>
     </section> 
+    <script src="accessibility.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -146,6 +146,7 @@
         rights to this work.
       </p>
     </section>
+    <script src="accessibility.js"></script>
   </body>
 </html>
 

--- a/new_groups.html
+++ b/new_groups.html
@@ -74,5 +74,6 @@
         rights to this work.
       </p>
     </section>
+    <script src="accessibility.js"></script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -19,17 +19,17 @@ body {
     background-color:black;
     padding:0.2em;
 }
-#accessibility:target{
+#accessibility:target, #accessibility.inverted {
     color:white;
     background-color:black;
 }
-#accessibility:target a{
+#accessibility:target a, #accessibility.inverted a {
     color:white;
 }
-#accessibility:target .wob{
+#accessibility:target .wob, #accessibility.inverted .wob {
     display:none;
 }
-#accessibility:target .bow{
+#accessibility:target .bow, #accessibility.inverted .bow {
     display:inline;
 }
 section {

--- a/uk_east_london.html
+++ b/uk_east_london.html
@@ -85,5 +85,6 @@
         rights to this work.
       </p>
     </section> 
+    <script src="accessibility.js"></script>
   </body>
 </html>

--- a/uk_edinburgh.html
+++ b/uk_edinburgh.html
@@ -153,5 +153,6 @@
         rights to this work.
       </p>
     </section> 
+    <script src="accessibility.js"></script>
   </body>
 </html>

--- a/uk_manchester.html
+++ b/uk_manchester.html
@@ -49,5 +49,6 @@ twitter, <a href="https://twitter.com/sjmarshy">@sjmarshy</a>, whichever is easi
       
       
     </section>
+    <script src="accessibility.js"></script>
   </body>
 </html>

--- a/uk_oxford.html
+++ b/uk_oxford.html
@@ -52,6 +52,7 @@
         rights to this work.
       </p>
     </section>
+    <script src="accessibility.js"></script>
   </body>
 </html>
 

--- a/uk_west_london.html
+++ b/uk_west_london.html
@@ -46,5 +46,6 @@
         rights to this work.
       </p>
     </section> 
+    <script src="accessibility.js"></script>
   </body>
 </html>

--- a/us_austin.html
+++ b/us_austin.html
@@ -73,5 +73,6 @@
         rights to this work.
       </p>
     </section> 
+    <script src="accessibility.js"></script>
   </body>
 </html>

--- a/us_boston.html
+++ b/us_boston.html
@@ -52,5 +52,6 @@
         rights to this work.
       </p>
     </section> 
+    <script src="accessibility.js"></script>
   </body>
 </html>

--- a/us_sanfrancisco.html
+++ b/us_sanfrancisco.html
@@ -133,5 +133,6 @@
         rights to this work.
       </p>
     </section> 
+    <script src="accessibility.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The `target` hack will keep working fine on unsupported browsers, but where possible we can use JavaScript to change the colours without having to jump to an anchor.
