### PR TITLE
list bullets are a nice thing. Lets get them back.

### DIFF
--- a/style.css
+++ b/style.css
@@ -59,9 +59,6 @@ li {
   line-height: 1.5;
 }
 
-li::before {
-}
-
 ul.rules > li {
   line-height: 1.8;
 }
@@ -71,11 +68,15 @@ ul.groups > li {
   margin-top: 1em;
   margin-bottom: 0.5em;
 }
+
 ul.groups li li {
   font-weight: normal;
 }
 
-li ul li::before {
+ul li::before {
   content : '- ';
 }
 
+ul.groups li::before {
+  content: '';
+}


### PR DESCRIPTION
I've left them out for the groups listing because that seems to be what the original author desired and I'm indifferent as to whether this is a good thing. I mostly want them back for the rules so they stop looking like badly formatted paragraphs...
