### PR TITLE
Use prefix attribute instead of deprecated xmlns: (again)

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -35,7 +35,7 @@
         {{ content }}
         </section>
         <section id="license">
-            <p xmlns:dct="http://purl.org/dc/terms/">
+            <p prefix="dct: http://purl.org/dc/terms/">
                 <a rel="license"
                 href="http://creativecommons.org/publicdomain/zero/1.0/">
                     <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />


### PR DESCRIPTION
The changes from d8e946f333824de9ba07188a453672a877fc1cd3 got lost in the #103 merge.
