### PR TITLE
rm portland external link, update syntax/formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@ title: Computer Anonymous
         <ul>
             <li><a href="us_austin.html">Austin</a></li>
             <li><a href="us_boston.html">Boston</a></li>
-            <li><a href="http://billmill.org/computer/">Portland, Maine</a></li>
+            <li><a href="us_portland.html">Portland</a></li>
             <li><a href="us_sanfrancisco.html">San Francisco</a></li>
         </ul>
     </li>

--- a/us_boston.html
+++ b/us_boston.html
@@ -2,29 +2,29 @@
 layout: base
 title: Computer Anonymous - Boston
 ---
-      <h1>Computer Anonymous — Boston</h1>
-      <p>Read <a href="index.html">the overview</a> if you haven't already.</p>
-      <p>//</p>
-      <h2>The Meetings</h2>
-      <p>First meeting:</p>
-      <p>Location: Tentatively, <a href="http://www.miracleofscience.us/">Miracle of Science</a>, 321 Massachusetts Ave <a href="http://goo.gl/CJAcPf">[Google Maps]</a></p>
-      <ul>
-        <li>Tasty food</li>
-        <li>Periodic table-themed menu</li>
-        <li>Near the Central T stop</li>
-      </ul>
-      <p>Time: Tentatively, Thursday Oct 17th!</p>
-      <p>These things are all up for debate and discussion, use IRC and Twitter!</p>
-      <p>//</p>
-      <h3>Ideas for Future Meetings</h3>
-      <p>Miracle of Science is pretty OK for Cambridge-ites, but elsewhere may work better for the majority, and we can jump around to different locations—let us know where you hang out!</p>
-      <p>//</p>
-      <h3>The People</h3>
-      <p>Talk to us if you want to attend or just turn up!</p>
-      <ul>
-        <li><a href="https://twitter.com/flowerhack">@flowerhack</a> [flowerhack on freenode]</li>
-        <li><a href="https://twitter.com/decklin">@decklin</a> [decklin on freenode]</li>
-        <li><a href="https://twitter.com/nynexrepublic">@nynexrepublic</a> [mkb218 on freenode]</li>
-        <li><a href="https://twitter.com/patcable">@patcable</a> [mrbucket on irc]</li>
-      </ul>
-      <p>Ping us!</p>
+    <h1>Computer Anonymous — Boston</h1>
+    <p>Read <a href="index.html">the overview</a> if you haven't already.</p>
+    <p>//</p>
+    <h2>The Meetings</h2>
+    <p>First meeting:</p>
+    <p>Location: Tentatively, <a href="http://www.miracleofscience.us/">Miracle of Science</a>, 321 Massachusetts Ave <a href="http://goo.gl/CJAcPf">[Google Maps]</a></p>
+    <ul>
+      <li>Tasty food</li>
+      <li>Periodic table-themed menu</li>
+      <li>Near the Central T stop</li>
+    </ul>
+    <p>Time: Tentatively, Thursday Oct 17th!</p>
+    <p>These things are all up for debate and discussion, use IRC and Twitter!</p>
+    <p>//</p>
+    <h3>Ideas for Future Meetings</h3>
+    <p>Miracle of Science is pretty OK for Cambridge-ites, but elsewhere may work better for the majority, and we can jump around to different locations—let us know where you hang out!</p>
+    <p>//</p>
+    <h3>The People</h3>
+    <p>Talk to us if you want to attend or just turn up!</p>
+    <ul>
+      <li><a href="https://twitter.com/flowerhack">@flowerhack</a> [flowerhack on freenode]</li>
+      <li><a href="https://twitter.com/decklin">@decklin</a> [decklin on freenode]</li>
+      <li><a href="https://twitter.com/nynexrepublic">@nynexrepublic</a> [mkb218 on freenode]</li>
+      <li><a href="https://twitter.com/patcable">@patcable</a> [mrbucket on irc]</li>
+    </ul>
+    <p>Ping us!</p>

--- a/us_portland.html
+++ b/us_portland.html
@@ -1,0 +1,75 @@
+---
+layout: base
+title: Computer Anonymous - Portland
+---
+    <h1>Computer.</h1>
+    <h2>Computer ?</h2>
+    <h3>Computer :-(</h3>
+    <p>Now you understand, let's go to computer anonymous.</p>
+    <p><a href="#groups">See if there's one already where you live</a> at the bottom of the page, or start one by <a href="https://github.com/tef/computer">forking the repository</a>, making your changes, and submitting a pull request.</p>
+    <h4>The Plan</h4>
+    <p>This might be the group for you if you want to meet socially conscious nerds, to talk about interesting things: This is not an enterprenuerial meetup, nor is it networking. It is a support group.</p>
+    <ul>
+      <li>- We go to a good pub.</li>
+      <li>- We eat food.</li>
+      <li>- We say 'computer'.</li>
+      <li>- We drink, be it beer, cocktails or soft drinks.</li>
+    </ul>
+    <p>There aren't regularly organized talks, workshops, or otherwise.</p>
+    <p>It's just a chance to meet good people and talk about good and bad things.</p>
+    <p>We will talk computer a lot, but we'd also like to not talk computer too.</p>
+    <p>We might have a talk, we might try and learn a thing, but at the end of the day we're just here not to be alone when we find ourselves saying "computer".</p>
+    <h4>Imposters Welcome</h4>
+    <p>This is a support group. No-one knows what they are doing.</p>
+    <p>If you're worried about not being computer enough, come.</p>
+    <p>If your day job isn't code, come.</p>
+    <p>If you think you're an imposter, come.</p>
+    <p>This isn't a group of experts, just people.</p>
+    <p>We are interested in the social and technical problems.</p>
+    <h4>The Rules</h4>
+    <p><a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">A standard code of conduct applies</a>. This means: Don't harass people. Don't make exclusionary jokes. Don't even make them "ironically".</p>
+    <ul>
+      <li>- We want to be inclusive; we don't welcome homophobic, racist, transphobic, or sexist behavior, amongst others.</li>
+      <li>- We think feminism is a good thing; we think brogramming is a bad thing.</li>
+      <li>- We're a very informal and ad-hoc group right now, so if you piss us off you won't be invited again.</li>
+      <li>- Although we're meeting in a pub, there is no expectation or pressure to drink alcohol. Don't question anyone's choice of drink.</li>
+    </ul>
+    <p>The rules will become more explicit as we grow, and we're always trying to change for the better.</p>
+    <h4>The People</h4>
+    <p>On IRC: irc.freenode.net <a href="irc://irc.freenode.net/##computer">##computer</a></p>
+    <p><a href="http://twitter.com/WhyComputer">@WhyComputer</a> on twitter</p>
+    <p>If you want to attend, say hello to someone, and they will drag you along.</p>
+    <p>We are making plans on <a href="https://github.com/llimllib/computer">https://github.com/llimllib/computer</a>, and if you have fixes or comments, open an issue! (p.s. Ask @llimllib to add you as a contributor)</p>
+    <h4 id="groups">The Groups</h4>
+      <ul class="groups">
+        <li>
+          UK
+          <ul>
+            <li><a href="uk_east_london.html">East London</a></li>
+            <li><a href="uk_west_london.html">West London</a></li>
+            <li><a href="uk_edinburgh.html">Edinburgh</a></li>
+            <li><a href="uk_oxford.html">Oxford</a></li>
+            <li><a href="uk_manchester.html">Manchester</a></li>
+            <li><a href="uk_cardiff.html">Cardiff</a></li>
+        </ul>
+    </li>
+    <li>
+        USA
+        <ul>
+            <li><a href="us_austin.html">Austin</a></li>
+            <li><a href="us_boston.html">Boston</a></li>
+            <li><a href="us_portland.html">Portland</a></li>
+            <li><a href="us_sanfrancisco.html">San Francisco</a></li>
+        </ul>
+    </li>
+    <li>
+        Elsewhere
+        <ul>
+            <li><a href="ca_nl_stjohns.html">St. John’s, NL, Canada</a></li>
+            <li><a href="de_berlin.html">Berlin</a></li>
+            <li><a href="de_hamburg.html">Hamburg</a></li>
+            <li><a href="ca_qc_montreal.html">Montr&eacute;al</a></li>
+          </ul>
+        </li>
+      </ul>
+      <p>If you’d like to start a group nearer you, you can fork the GitHub repo and send us a pull request. We have some help and advice for those <a href="running_a_group.html">starting or running a group</a>, which covers finding venues, handling problems, and people who can help with using GitHub.</p>


### PR DESCRIPTION
The Portland, ME group had linked externally from the github repository - pulled their source and merged it into a jekyll friendly static file. Updated hyperlinks to the now internal us_portland.html file and cleaned up both syntax and formatting where necessary.
