### PR TITLE
Remove pembury tavern link from central London page

### DIFF
--- a/uk_central_london.html
+++ b/uk_central_london.html
@@ -8,7 +8,7 @@ title: Computer Anonymous Central London
 </p>
 
 <h2>The Meetings</h2>
-      <p>We meet on the first Thursday of the month, at <a href="http://www.individualpubs.co.uk/pembury/">The Pembury Tavern</a>, <a href="http://osm.org/go/euu7IkpEN-?m=">90 Amhurst Rd, E8 1JH</a></p>
+      <p>We meet on the first Thursday of the month.</p>
 
       <h3>Venue</h3>
 


### PR DESCRIPTION
Also, would the Central London organizers be willing to choose a date that doesn't clash with the East London meetup? It'd be a shame to cannibalise the attendance at either, and I, for one would happily attend both! (cc @tef @ntlk @doismellburning)
