### PR TITLE
Reduce strength of wording re public logs

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@ title: Computer Anonymous
 
       <h4>The People</h4>
 
-      <p>On IRC: irc.freenode.net <a href="irc://irc.freenode.net/%23%23computer">##computer</a>. IRC is logged by members, but not publicly.</p>
+      <p>On IRC: irc.freenode.net <a href="irc://irc.freenode.net/%23%23computer">##computer</a>. IRC is logged by members, who are asked not to publicise their logs.</p>
 
       <p><a href="http://twitter.com/WhyComputer">@WhyComputer</a> on twitter</p>
 


### PR DESCRIPTION
I feel that if you say anything stronger than "people are encouraged not
to publish their logs" you're giving people a false and inappropriate
sense of security.
