### PR TITLE
Add Doodle link to Austin page

### DIFF
--- a/us_austin.html
+++ b/us_austin.html
@@ -11,6 +11,9 @@ title: Computer Anonymous - Austin
 <h2>The Meetings</h2>
 
 <p>Next meeting:</p>
+<p>Vote on the next meeting at our <a href="http://doodle.com/nnv6zs8wkuy4s5yy">Doodle</a> page. We've added some weekend possibilities. Use the comments to suggest a place.</p>
+
+<p>Past meetings:</p>
 
 <p>Location: <a href="http://www.dogandduckpub.com/">Dog and Duck</a>, 406 West 17th Street</p>
 <p>Time: Wednesday, Oct. 23rd at ~6pm!</p>


### PR DESCRIPTION
Added a Doodle poll to the Austin page. I created the Doodle poll this morning; the link is http://doodle.com/nnv6zs8wkuy4s5yy
