### PR TITLE
Moved Doodle link to lower subhead

### DIFF
--- a/us_austin.html
+++ b/us_austin.html
@@ -10,10 +10,10 @@ title: Computer Anonymous - Austin
 
 <h2>The Meetings</h2>
 
-<p>Next meeting:</p>
-<p>Vote on the next meeting at our <a href="http://doodle.com/nnv6zs8wkuy4s5yy">Doodle</a> page. We've added some weekend possibilities. Use the comments to suggest a place.</p>
+<p>Next Meeting:</p>
+<p>TBD.</p>
 
-<p>Past meetings:</p>
+<p>Past Meetings:</p>
 
 <p>Location: <a href="http://www.dogandduckpub.com/">Dog and Duck</a>, 406 West 17th Street</p>
 <p>Time: Wednesday, Oct. 23rd at ~6pm!</p>
@@ -29,7 +29,7 @@ title: Computer Anonymous - Austin
 
 <h3>Ideas for Future Meetings</h3>
 
-<p>We've already met at Hopfields, and we're going to try the Dog and Duck, but perhaps there are better places? We can jump around, of course. Tell us where you hang out!</p>
+<p>Vote on the next meeting at our <a href="http://doodle.com/nnv6zs8wkuy4s5yy">Doodle</a> page. We've added some weekend possibilities. We've already met at Hopfields and the Dog and Duck, but perhaps there are better places? Tell us where you hang out in the Doodle comments!</p>
 
 <p>//</p>
 


### PR DESCRIPTION
Moved Doodle poll to "Ideas for Future Meetings" header. Made header capitalization consistent. I'm an over-editor.
