### PR TITLE
Update "Past meetings" for Austin

### DIFF
--- a/us_austin.html
+++ b/us_austin.html
@@ -11,6 +11,10 @@ title: Computer Anonymous - Austin
 <h2>The Meetings</h2>
 
 <p>Next Meeting:</p>
+<p>Vote on the next meeting at our <a href="http://doodle.com/nnv6zs8wkuy4s5yy">Doodle</a> page! 
+
+<p>Past Meetings:</p>
+
 <p>Location: <a href="http://www.draughthouse.com/">Draught House Pub and Brewery</a>, 4112 Medical Parkway</p>
 <p>Time: Wednesday, Nov. 6 at ~6pm!</p>
 <ul>
@@ -18,8 +22,6 @@ title: Computer Anonymous - Austin
     <li><a href="http://www.taplister.com/bars/draught-house-pub-brewery/40b13b00f964a5209af31ee3/">Cool beers</a></li>
     <li>Central location, on the #3 bus route</li>
 </ul>
-
-<p>Past Meetings:</p>
 
 <p>Location: <a href="http://www.dogandduckpub.com/">Dog and Duck</a>, 406 West 17th Street</p>
 <p>Time: Wednesday, Oct. 23rd at ~6pm!</p>


### PR DESCRIPTION
Updated past Austin meetings, put Doodle link in "next meeting" section.
