### PR TITLE
Add twitter account, other misc

### DIFF
--- a/us_austin.html
+++ b/us_austin.html
@@ -11,30 +11,14 @@ title: Computer Anonymous - Austin
 <h2>The Meetings</h2>
 
 <p>Next Meeting:</p>
-<p>Location: <a href="http://www.beerknurd.com/stores/austin/">The Flying Saucer</a>, 815 W. 47th St., in the Triangle</p>
-<p>Time: Wednesday, Nov. 20 at ~6pm!</p>
-<ul>
-    <li><a href="http://www.beerknurd.com/stores/austin/food">Food</a></li>
-    <li><a href="http://www.beerknurd.com/stores/austin/beer">Cool beers</a></li>
-    <li>Central location, on the 1L, 1M, and 101 bus routes</li>
-</ul>
+<p><p>Vote on the next meeting at our <a href="http://doodle.com/nnv6zs8wkuy4s5yy">Doodle</a> page, and suggest a location in the comments!</p>
 
 <p>Past Meetings:</p>
 
-<p>Location: <a href="http://www.draughthouse.com/">Draught House Pub and Brewery</a>, 4112 Medical Parkway</p>
-<p>Time: Wednesday, Nov. 6 at ~6pm!</p>
 <ul>
-    <li>Food: <a href="http://mmmpanadas.com/">mmmpanadas</a> food truck </li>
-    <li><a href="http://www.taplister.com/bars/draught-house-pub-brewery/40b13b00f964a5209af31ee3/">Cool beers</a></li>
-    <li>Central location, on the #3 bus route</li>
-</ul>
-
-<p>Location: <a href="http://www.dogandduckpub.com/">Dog and Duck</a>, 406 West 17th Street</p>
-<p>Time: Wednesday, Oct. 23rd at ~6pm!</p>
-<ul>
-    <li>British pub, burgers, sandwiches, salads and 'pub grub'</li>
-    <li><a href="http://www.taplister.com/bars/40b13b00f964a52095f31ee3">Cool beers</a></li>
-    <li>Central location</li>
+    <li>Wednesday, Nov. 20 at ~6pm, <a href="http://www.beerknurd.com/stores/austin/">The Flying Saucer</a></li>
+    <li>Wednesday, Nov. 6 at ~6pm, <a href="http://www.draughthouse.com/">Draught House Pub and Brewery</a></li>
+    <li>Wednesday, Oct. 23rd at ~6pm, <a href="http://www.dogandduckpub.com/">Dog and Duck</a></li>
 </ul>
 
 <p>These things are all up for debate and discussion, use IRC and Twitter!</p>
@@ -48,6 +32,8 @@ title: Computer Anonymous - Austin
 <p>//</p>
 
 <h3>The People</h3>
+
+<p><a href="https://twitter.com/WhyComputerATX">@WhyComputerATX</a></p>
 
 <p>Talk to us if you want to attend or just turn up!</p>
 


### PR DESCRIPTION
Add @WhyComputerATX twitter account. Consolidate past meetings. Add link to Doodle page to schedule next meeting.
