### PR TITLE
Adding a link to Freenode's web IRC interface

### DIFF
--- a/uk_edinburgh.html
+++ b/uk_edinburgh.html
@@ -69,7 +69,7 @@ title: Computer Anonymous - Edinburgh
       
       <p>You can add your name by doing a fork and pull request on the <a href="https://github.com/computeranonymous/computer/blob/gh-pages/uk_edinburgh.html">github page</a>, or by emailing computercomputercomputer at glastonbridge dot co dot uk.  The latter method is somewhat unreliable and uses a high-latency meat interface, but it tries hard.</p>
 
-      <p>There is also an edinburgh-specific IRC channel on freenode called ##computer.ed</p>
+      <p>There is also an edinburgh-specific IRC channel on freenode called ##computer.ed (<a href="http://webchat.freenode.net/?channels=##computer.ed">web IRC interface)</a></p>
       
       <h3>Venues:</h3>
       


### PR DESCRIPTION
Adding a link to Freenode's official web IRC interface for people without an IRC client currently installed on their computer (e.g., for those at work or on a shared public terminal).
