### PR TITLE
Meeting venue and date for April 2014 (Edinburgh)

### DIFF
--- a/uk_edinburgh.html
+++ b/uk_edinburgh.html
@@ -9,8 +9,8 @@ title: Computer Anonymous - Edinburgh
       <h2>Next Meeting</h2>
       
       <ul>
-            <li>Monday the 10th of March at 7pm.</li>
-            <li>Biblos (Chambers Street, <a href="https://goo.gl/maps/1ejz7">here</a>).</li>
+            <li>Thursday the 10th of April at 7pm.</li>
+            <li>B+B Edinburgh (Rothesay Terrace, <a href="https://goo.gl/maps/v5npr">here</a>).</li>
       </ul>
       
       <h2>The Meetings</h2>
@@ -76,6 +76,10 @@ title: Computer Anonymous - Edinburgh
       <h4>Previous meeting experiences</h4>
       
       <p>The Southern was okay, but a bit noisy. I know some people struggled to hear conversations.</p>
+      
+      <p>The Royal Dick was found to be a little awkward for people to get to.</p>
+      
+      <p>Biblos has served us well for a few months, but it has been suggested that somewhere people feel less pressure to buy drinks might be a good idea.</p>
 
       <p>The usual suspects for a techy meetup are:</p>
       <ul>
@@ -139,9 +143,9 @@ title: Computer Anonymous - Edinburgh
 
       <h1>Previous Meetings</h1>
       
-      <h2>January / February 2014</h2>
+      <h2>January / February / March 2014</h2>
       
-      <p>These meetings were held at Biblos on 7th January and 10th February respectively.  12 people attended in January (with comings and goings over the course of the evening) and 5 people were present in February.</p>
+      <p>These meetings were held at Biblos on 7th January, 10th February and 10th March respectively.  12 people attended in January (with comings and goings over the course of the evening) and 5 people were present in February.</p>
       
       <h2>December meeting</h2>
       
@@ -150,13 +154,6 @@ title: Computer Anonymous - Edinburgh
             <li><a href="https://www.google.co.uk/maps/preview#!data=!1m4!1m3!1d2176!2d-3.1820669!3d55.9393032!4m12!2m11!1m10!1s0x0%3A0x501b49783f43819c!3m8!1m3!1d71503!2d-3.2053386!3d55.9412083!3m2!1i1024!2i768!4f13.1">The Royal Dick, 1 Summerhall Pl EH9</a></li>
             <li>You have to go through the Sumerhall building to the courtyard in order to get to the pub</li>
             <li>Table is booked from 6.30pm, so feel free to show up early</li>
-      </ul>
-      
-      There is also a Holiday Special for those who want to meet between Christmas and New Year:
-      
-      <ul>
-            <li>Friday, 27th Decemeber, 7pm (2013-12-27T19:00Z)</li>
-            <li>TBD at the next meeting</li>
       </ul>
       
       <h2>Meeting The Second.</h2>


### PR DESCRIPTION
Monday seems to be an awkward night for many, so Thursday was proposed as an alternative. Pajh (@gominokouhai) has offered space in B+B Edinburgh (https://goo.gl/maps/v5npr) on Rothesay Terrace as a venue for April. The hotel has a very comfortable meeting space, a bar and inexpensive but rather tasty coffee. It is located just off of Queensferry Street, near the west end of Princes Street. While there is no food available on premises, there are plenty of options nearby (e.g., Wannaburger) if people would like to grab something beforehand.

I have also added further details of past meetings and removed some historical information that is no longer pertinent.
