### PR TITLE
redirect portland to caportland.me

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>redirecting</title>
+  <link rel="canonical" href="{{ page.redirect_to }}"/>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+  <meta http-equiv="refresh" content="0;url={{ page.redirect_to }}" />
+  <script>location='{{ page.redirect_to }}'</script>
+  </head>
+  <body>
+      <h1>Redirecting...</h1>
+      <a href="{{ page.redirect_to }}">Click here if you are not redirected.</a>
+  </body>
+</html>
+

--- a/us_portland.html
+++ b/us_portland.html
@@ -1,27 +1,5 @@
 ---
-layout: base
-title: Computer Anonymous - Portland
+layout: redirect
+sitemap: false
+redirect_to: http://caportland.me
 ---
-<h1>Computer Anonymous — Portland, ME</h1>
-
-<p>This might be the group for you if you want to meet socially conscious nerds to talk about interesting things. This is not an entrepreneurial meetup, nor is it networking: It is a support group, a place to meet good people and talk about good and bad things.</p>
-
-<p>Although education and outreach are both important to us, the primary goal is to create a social group for people in and around tech, from all backgrounds, where they feel comfortable and welcome.</p>
-
-<p>If you're interested in joining, why not <a href="http://portland-ca-slackin.herokuapp.com">join our slack community</a>?</p>
-
-<h3>The Meetings</h3>
-
-<p>Our May meeting will be <b>May 3, 7PM at <a href="http://www.slabportland.com/">Slab</a></b></p>
-
-<p>Hope to see you there!
-
-<h3>Questions/Problems?</h3>
-
-<p>Talk to us if you want to attend, or just turn up!</p>
-
-<p><a href="http://portland-ca-slackin.herokuapp.com">Join our slack community!</a></p>
-
-<p>We're on twitter at: <a href="https://twitter.com/jsmecham">@jsmecham</a> <a href="https://twitter.com/llimllib">@llimllib</a> <a href="https://twitter.com/neruson">@neruson</a> <a href="https://twitter.com/n01s3">@n01s3</a> <a href="https://twitter.com/chrisvermilion">@chrisvermilion</a> <a href="https://twitter.com/sstatik">@sstatik</a>
-
-<p>Feel free to email <a href="mailto:ComputerAnonymousPortland@gmail.com">ComputerAnonymousPortland@gmail.com</a> to join the email list, or if you have any private questions.</p>


### PR DESCRIPTION
The Portland CA meetup is still ongoing, and we have our own website so we'd like to redirect to it.

I tested the redirect layout by running jekyll locally and visiting the us_portland page, which redirected as expected.

@flowerhack I only tagged you because you made the last three commits and I don't know who else to tag; feel free to let me know if there's somebody better placed.