### PR TITLE
Proposal: move official website IRC links to libera.chat

### DIFF
--- a/de_berlin.html
+++ b/de_berlin.html
@@ -32,8 +32,8 @@ title: Computer Anonym - Berlin
       <h4>The People</h4>
       <h4><i>Die Leute</i></h4>
 
-      <p>On IRC: irc.freenode.net <a href="irc://irc.freenode.net/%23%23computer">##computer</a> (Global) and <a href="irc://irc.freenode.net/%23dercomputer">#dercomputer</a> (german speaking)</p>
-      <p><i>Auf IRC: irc.freenode.net </i><a href="irc://irc.freenode.net/%23%23computer">##computer</a> (Weltweit) und <a href="irc://irc.freenode.net/%23dercomputer">#dercomputer</a> (deutschsprachig)</p>
+      <p>On IRC: <a href="https://libera.chat/guides/connect">irc.libera.chat</a> <a href="irc://irc.libera.chat/%23%23computer">##computer</a></p>
+      <p><i>Auf IRC: <a href="https://libera.chat/guides/connect">irc.libera.chat</a> </i><a href="irc://irc.libera.chat/%23%23computer">##computer</a></p>
 
       <p><a href="http://twitter.com/WhyComputer">@WhyComputer</a> on twitter</p>
       <p><i><a href="http://twitter.com/WhyComputer">@WhyComputer</a> auf Twitter</i></p>

--- a/de_hamburg.html
+++ b/de_hamburg.html
@@ -47,8 +47,8 @@ title: Computer Anonym - Hamburg
       <p>If you want to attend, say hello to someone, and they will drag you along.</p>
       <p><i>Wenn du kommen willst, sag "hallo" zu jemand, und sie/er wird dich einpacken und mitnehmen.</i></p>
 
-      <p>On IRC: irc.freenode.net <a href="irc://irc.freenode.net/%23%23computer">##computer</a> (Global) and <a href="irc://irc.freenode.net/%23dercomputer">#dercomputer</a> (german speaking)</p>
-      <p><i>Auf IRC: irc.freenode.net </i><a href="irc://irc.freenode.net/%23%23computer">##computer</a> (Weltweit) und <a href="irc://irc.freenode.net/%23dercomputer">#dercomputer</a> (deutschsprachig)</p>
+      <p>On IRC: <a href="https://libera.chat/guides/connect">irc.libera.chat</a> <a href="irc://irc.libera.chat/%23%23computer">##computer</a></p>
+      <p><i>Auf IRC: <a href="https://libera.chat/guides/connect">irc.libera.chat</a> </i><a href="irc://irc.libera.chat/%23%23computer">##computer</a></p>
 
       <p><a href="http://twitter.com/WhyComputer">@WhyComputer</a> on twitter</p>
       <p><i><a href="http://twitter.com/WhyComputer">@WhyComputer</a> auf Twitter</i></p>

--- a/index.de.html
+++ b/index.de.html
@@ -60,10 +60,9 @@ title: Computer Anonymous
 
       <h4>Die Leute</h4>
 
-      <p>Im IRC Chat: irc.freenode.net
+      <p>Im IRC Chat: <a href="https://libera.chat/guides/connect">irc.libera.chat</a>
         <ul>
-          <li>generell und englischsprachig: <a href="irc://irc.freenode.net/%23%23computer">##computer</a></li>
-          <li>deutschsprachiger Raum: <a href="irc://irc.freenode.net/%23%23computer">#dercomputer</a></li>
+          <li>generell und englischsprachig: <a href="irc://irc.libera.chat/%23%23computer">##computer</a></li>
         </ul>
 
         Der IRC Chat Protokoll wird durch die Nutzer festgehalten. Die Nutzer sind jedoch angehalten diese Protokolle nicht zu ver&ouml;ffentlichen.</p>

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@ title: Computer Anonymous
 
       <h4>The People</h4>
 
-      <p>On IRC: irc.freenode.net <a href="irc://irc.freenode.net/%23%23computer">##computer</a>. IRC is logged by members, who are asked not to publicise their logs.</p>
+      <p>On IRC: <a href="https://libera.chat/guides/connect">irc.libera.chat</a> in the <a href="irc://irc.libera.chat/%23%23computer">##computer</a> channel. IRC is logged by members, who are asked not to publicise their logs.</p>
 
       <p><a href="http://twitter.com/WhyComputer">@WhyComputer</a> on twitter</p>
 

--- a/us_sanfrancisco.html
+++ b/us_sanfrancisco.html
@@ -11,7 +11,7 @@ title: Computer Anonymous - San Francisco
 
       <h2>The Meetings</h2>
 
-      <p>Join us on IRC at ##computer on freenode if you want in. :)</p>
+      <p>Join us on IRC at ##computer on <a href="https://libera.chat/guides/connect">irc.libera.chat</a> if you want in. :)</p>
 
       <p>Computer Anonymous SF has been on hiatus for a while but tends to meet on occasional Saturdays for brunch</p>
 


### PR DESCRIPTION
This commit moves website references to ##computer from freenode to libera.chat, and removes references to #dercomputer as it appears empty.

Feel free to reject or sit on it especially if discussion is desired, I just happen to be handy with grep.